### PR TITLE
Fix request header case

### DIFF
--- a/Source/ResponseData.as
+++ b/Source/ResponseData.as
@@ -16,7 +16,7 @@ class ResponseData
 		m_raw = req.String();
 
 		string contentType;
-		m_headers.Get("content-type", contentType);
+		m_headers.Get("Content-Type", contentType);
 		if (contentType == "application/json") {
 			m_pretty = Json::Write(req.Json(), true);
 		}


### PR DESCRIPTION
Pretty response tab wasn't working for a while, and after checking, it seems that the Nadeo API has changed the casing for the headers. I tested and now it works with this change