### PR TITLE
Support request body for DELETE

### DIFF
--- a/Source/RequestData.as
+++ b/Source/RequestData.as
@@ -65,6 +65,7 @@ class RequestData
 		switch (m_method) {
 			case Net::HttpMethod::Post:
 			case Net::HttpMethod::Put:
+			case Net::HttpMethod::Delete:
 			case Net::HttpMethod::Patch:
 				return true;
 		}


### PR DESCRIPTION
Found it while documenting some endpoints. The game uses the endpoint `https://prod.trackmania.core.nadeo.online/maps/favorites` with the DELETE method to delete maps from your favorites lists by passing an object with the mapUid as the body.

From Wireshark:

<img width="492" height="126" alt="image" src="https://github.com/user-attachments/assets/29c8afa9-34a6-412c-84d2-ffd7b553cc92" />
<img width="261" height="51" alt="image" src="https://github.com/user-attachments/assets/104f8b42-fa18-4eaa-8f5e-6deb5ff5eae6" />




